### PR TITLE
Dockerfile: adapt for WAFL and add test program

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update
 RUN apt-get install -y software-properties-common
@@ -11,12 +11,15 @@ RUN apt-get install -y \
     build-essential \
     cmake \
     libtool \
-    llvm-6.0 \
+    llvm-14 \
+    llvm-14-dev \
+    clang-14 \
     make \
     ninja-build \
     sudo \
     unzip \
-    zlib1g-dev
+    zlib1g-dev \
+    patchelf
 
 RUN apt-get clean autoclean
 RUN apt-get autoremove -y
@@ -29,5 +32,30 @@ WORKDIR /build
 
 RUN cmake -G Ninja /code -DCMAKE_BUILD_TYPE=RelWithDebInfo
 RUN ninja
+RUN ninja install
+RUN patchelf --add-needed /usr/local/lib/libWAVM.so /usr/local/bin/wavm
 
-CMD /bin/bash
+WORKDIR /code/AFLplusplus
+RUN make WAFL_MODE=1 TEST_MMAP=1 install
+
+
+# setup example program for fuzzing
+RUN apt-get install -y git wget tar
+WORKDIR /
+RUN wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sdk-20.0-linux.tar.gz && \
+    tar xvf wasi-sdk-20.0-linux.tar.gz
+ENV WASI_SDK_PATH=/wasi-sdk-20.0
+RUN git clone https://github.com/AFLplusplus/fuzzer-challenges
+RUN cd fuzzer-challenges && \
+    /wasi-sdk-20.0/bin/clang -O0 -g --target=wasm32-wasi test-u8.c -D__AFL_COMPILER -o test-u8.wasm
+
+RUN cd fuzzer-challenges/libfuzzer && \
+    /wasi-sdk-20.0/bin/clang++ -O0 -g --target=wasm32-wasi SimpleTest.cpp -fno-exceptions -D__AFL_COMPILER -o SimpleTest.wasm
+ENV AFL_SKIP_CPUFREQ=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_SKIP_BIN_CHECK=1
+RUN mkdir /in && mkdir /out && echo seed > /in/seed
+
+ENV __AFL_PERSISTENT=1 __AFL_SHM_FUZZ=1
+
+# wavm crashes for the C++ SimpleTest.wasm :/
+# CMD afl-fuzz -i /in/ -o /out/ wavm run /fuzzer-challenges/libfuzzer/SimpleTest.wasm
+CMD afl-fuzz -i /in/ -o /out/ wavm run /fuzzer-challenges/test-u8.wasm

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,11 @@ RUN wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-2
 ENV WASI_SDK_PATH=/wasi-sdk-20.0
 RUN git clone https://github.com/AFLplusplus/fuzzer-challenges
 RUN cd fuzzer-challenges && \
-    /wasi-sdk-20.0/bin/clang -O0 -g --target=wasm32-wasi test-u8.c -D__AFL_COMPILER -o test-u8.wasm
+    /wasi-sdk-20.0/bin/clang -O0 -g --target=wasm32-wasi test-u8.c -o test-u8.wasm /code/standalone.c
 
-RUN cd fuzzer-challenges/libfuzzer && \
-    /wasi-sdk-20.0/bin/clang++ -O0 -g --target=wasm32-wasi SimpleTest.cpp -fno-exceptions -D__AFL_COMPILER -o SimpleTest.wasm
 ENV AFL_SKIP_CPUFREQ=1 AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_SKIP_BIN_CHECK=1
 RUN mkdir /in && mkdir /out && echo seed > /in/seed
 
 ENV __AFL_PERSISTENT=1 __AFL_SHM_FUZZ=1
 
-# wavm crashes for the C++ SimpleTest.wasm :/
-# CMD afl-fuzz -i /in/ -o /out/ wavm run /fuzzer-challenges/libfuzzer/SimpleTest.wasm
 CMD afl-fuzz -i /in/ -o /out/ wavm run /fuzzer-challenges/test-u8.wasm

--- a/standalone.c
+++ b/standalone.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size);
+
+int main()
+{
+	size_t buf_size = 16, buf_used = 0;
+	uint8_t *buf = NULL;
+
+	do // read the file passed through stdin into buf
+	{
+		buf_size *= 2;
+		buf = (uint8_t*) realloc(buf, buf_size);
+		if (buf == NULL)
+		{
+			perror("allocation failed");
+			exit(EXIT_FAILURE);
+		}
+
+		const size_t bytes_read = fread(buf + buf_used, 1, buf_size - buf_used, stdin);
+		buf_used += bytes_read;
+		if (ferror(stdin))
+		{
+			fprintf(stderr, "error reading from stdin\n");
+			exit(EXIT_FAILURE);
+		}
+	} while (!feof(stdin));
+
+	printf("Read %lu bytes from stdin\n", buf_used);
+	LLVMFuzzerTestOneInput(buf, buf_used);
+	printf("Execution successful\n");
+	free(buf);
+}


### PR DESCRIPTION
Hi, I've updated WAVM's Dockerfile for WAFL, and tried running the fuzzing workflow on a [simple test program](https://github.com/AFLplusplus/fuzzer-challenges/blob/main/test-u8.c).
~~I'm not sure persistent mode is working correctly though (600 execs/s). Am I holding it wrong?~~