### PR TITLE
Add a `wasm::` prefix to JITted function symbols

### DIFF
--- a/Lib/LLVMJIT/EmitModule.cpp
+++ b/Lib/LLVMJIT/EmitModule.cpp
@@ -255,7 +255,7 @@ void LLVMJIT::emitModule(const IR::Module& irModule,
 			asLLVMType(llvmContext, functionType),
 			llvm::Function::ExternalLinkage,
 			functionIndex >= irModule.functions.imports.size()
-				? names.functions[functionIndex].name /* getExternalName("functionDef", functionIndex - irModule.functions.imports.size()) */
+				? std::string("wasm::") + names.functions[functionIndex].name /* getExternalName("functionDef", functionIndex - irModule.functions.imports.size()) */
 				: getExternalName("functionImport", functionIndex),
 			&outLLVMModule);
 		function->setCallingConv(asLLVMCallingConv(functionType.callingConvention()));

--- a/Lib/LLVMJIT/LLVMJIT.cpp
+++ b/Lib/LLVMJIT/LLVMJIT.cpp
@@ -53,6 +53,7 @@ namespace LLVMRuntimeSymbols {
 	static HashMap<std::string, void*> map = {
 		{"memmove", (void*)&memmove},
 		{"memset", (void*)&memset},
+		{"memcpy", (void*)&memcpy},
 #ifdef _WIN32
 		{"__chkstk", (void*)&__chkstk},
 		{"__CxxFrameHandler3", (void*)&__CxxFrameHandler3},


### PR DESCRIPTION
Re-using the module's function names as symbols is nice for debugging but can be fatal when they overlap with WAVM's runtime symbols.
This happens for WASM modules that include functions like `memset` or `memcpy` and leads to confusing segfaults.
